### PR TITLE
No need to specify path to .env file

### DIFF
--- a/api/config/database.dev.js
+++ b/api/config/database.dev.js
@@ -1,4 +1,4 @@
-require('dotenv').load({ path: '../.env' });
+require('dotenv').config();
 
 const {
   DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, DB_DATABASE,

--- a/api/config/database.prod.js
+++ b/api/config/database.prod.js
@@ -1,4 +1,4 @@
-require('dotenv').load({ path: '../.env' });
+require('dotenv').config();
 
 const {
   DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, DB_DATABASE,


### PR DESCRIPTION
The documentation does not specify the use of a path to the .env file. 